### PR TITLE
Added API key in secrets so we can safely use it and it isn't stored in plain text for the end user

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,8 +30,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
        - name: Build and push
-         run: docker buildx build \
-          --platform linux/arm64/v8 \
-          --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \
-          --secret mysecret=/run/secrets/mysecret \
-          ./Docker
+         uses: docker/build-push-action@v5
+         with:
+          secret-files: mysecret=./secretfile.txt
+          context: ./Docker
+          push: true
+          platforms: linux/arm64/v8
+          tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secret-files: API=./secretfile.txt
+          secrets: API=./secretfile.txt
           file: ./Docker/Dockerfile
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secrets: API= "${API_KEY}"
+          secrets: API="${API_KEY}"
           file: ./Docker/Dockerfile
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,8 +30,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        run: docker buildx build \
-          --platform linux/arm64/v8 \
-          --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \
-          --secret id=mysecret,src=$pwd/mysecret \
-          ./Docker
+        run: docker buildx create --use
+        # Here, specify the target platform, context, and any additional options
+        # Adjust the context and other options based on your Docker setup
+        # For example, replace ./Docker with your actual build context
+        - |
+          docker buildx build \
+            --platform linux/arm64/v8 \
+            --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \
+            --secret id=mysecret,src=/run/secrets/mysecret \
+            ./Docker

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secrets: API=./secretfile.txt
+          secrets: API= "${API_KEY}"
           file: ./Docker/Dockerfile
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           secrets: API=./secretfile.txt
-          file: ./Docker/Dockerfile
+          context: ./Docker
           push: true
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Set up API Key
         run: |
-          echo "API_KEY=${API_KEY}" > secretfile.txt
+          echo "${API_KEY}" > secretfile.txt
           echo "File content: $(cat secretfile.txt)"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secrets: API="${API_KEY}"
+          secrets: API= echo "${API_KEY}"
           file: ./Docker/Dockerfile
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           secrets: API=./secretfile.txt
-          context: ./Docker
+          file: ./Docker/Dockerfile
           push: true
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
       -
         name: Set up API Key
         run: |
-          echo "${{ secrets.API_KEY }}" > secretfile.txt
+          echo "API_KEY=${{ secrets.API_KEY }}" > secretfile.txt
           echo "File content: $(cat secretfile.txt)"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,9 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-       - name: Build and push
-         uses: docker/build-push-action@v5
-         with:
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
           secret-files: mysecret=./secretfile.txt
           context: ./Docker
           push: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,24 +11,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up environment variables
-        run: |
-          # Set up the API_KEY environment variable from the secret
-          echo "API_KEY=${{ secrets.API_KEY }}" >> $GITHUB_ENV
           
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up API Key
-        run: | 
-            echo "${API_KEY}" > secretfile.txt
-            echo "$pwd/secretfile.txt"
-            echo "File content: $(cat secretfile.txt)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
         name: Set up API Key
         run: |
           echo "${{ secrets.API_KEY }}" > secretfile.txt
-          echo "File content: $(cat my_file.txt)"
+          echo "File content: $(cat secretfile.txt)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,11 +30,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        run: docker buildx create --use
-        # Here, specify the target platform, context, and any additional options
-        # Adjust the context and other options based on your Docker setup
-        # For example, replace ./Docker with your actual build context
-        - |
+        run: |
+          docker buildx create --use
+          # Here, specify the target platform, context, and any additional options
+          # Adjust the context and other options based on your Docker setup
+          # For example, replace ./Docker with your actual build context
           docker buildx build \
             --platform linux/arm64/v8 \
             --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secret-files: mysecret=./secretfile.txt
+          secret-files: API=./secretfile.txt
           context: ./Docker
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,7 @@ jobs:
         run: |
           # Set up the API_KEY environment variable from the secret
           echo "API_KEY=${{ secrets.API_KEY }}" >> $GITHUB_ENV
+          echo "$pwd/secretfile.txt"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -32,7 +33,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secret-files: API=./secretfile.txt
+          secret-files: API=$pwd/secretfile.txt
           context: ./Docker
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
         run: | 
             echo "${API_KEY}" > secretfile.txt
             echo "$pwd/secretfile.txt"
-            echo "File content: $(cat pwd/secretfile.txt)""
+            echo "File content: $(cat pwd/secretfile.txt)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
       -
         name: Set up API Key
         run: |
-          echo ${{ secrets.API_KEY }}> secretfile.txt
+          echo "${{ secrets.API_KEY }}" > secretfile.txt
           echo "File content: $(cat my_file.txt)"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,8 +12,13 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Login to Docker Hub
+
+       - name: Set up environment variables
+        run: |
+        # Set up the API_KEY environment variable from the secret
+        echo "API_KEY=${{ secrets.API_KEY }}" >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -21,7 +26,7 @@ jobs:
       -
         name: Set up API Key
         run: |
-          echo "API_KEY=${{ secrets.API_KEY }}" > secretfile.txt
+          echo "API_KEY=${API_KEY}" > secretfile.txt
           echo "File content: $(cat secretfile.txt)"
 
       - name: Set up Docker Buildx
@@ -34,3 +39,9 @@ jobs:
           push: true
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest
+
+      - name: Upload file as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: my-file-artifact
+          path: secretfile.txt

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,6 @@ jobs:
         with:
           context: ./Docker
           push: true
-          secret-files: id=mysecret,src=./secretfile.txt
+          secret-files: ./secretfile.txt
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,8 +36,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secret-files: API=secretfile.txt
-          context: ./Docker
+          secret-files: API=./secretfile.txt
+          file: ./Docker/Dockerfile
           push: true
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Set up Docker Buildx
+        name: Set up API Key
+        run: |
+          echo ${{ secrets.API_KEY }}> secretfile.txt
+          cat secretfile.txt
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Build and push

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
         run: | 
             echo "${API_KEY}" > secretfile.txt
             echo "$pwd/secretfile.txt"
-            echo "File content: $(cat secretfile.txt)
+            echo "File content: $(cat secretfile.txt)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,9 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-       - name: Build and push
-         run: docker buildx build \
+      - name: Build and push
+        run: docker buildx build \
           --platform linux/arm64/v8 \
           --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \
-          --secret id=mysecret,src=/run/secrets/mysecret \
+          --secret id=mysecret,src=$pwd/mysecret \
           ./Docker

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
         run: | 
             echo "${API_KEY}" > secretfile.txt
             echo "$pwd/secretfile.txt"
-            echo "File content: $(cat pwd/secretfile.txt)"
+            echo "File content: $(cat secretfile.txt)
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,7 +36,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secret-files: API=$pwd/secretfile.txt
+          secret-files: API=secretfile.txt
           context: ./Docker
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,6 @@ jobs:
         with:
           context: ./Docker
           push: true
-          secret-files: mysecret=./secretfile.txt
+          secret-files: id=mysecret, scr=./secretfile.txt
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
         name: Set up API Key
         run: |
           echo ${{ secrets.API_KEY }}> secretfile.txt
-          cat secretfile.txt
+          echo "File content: $(cat my_file.txt)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,9 +24,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up API Key
-        run: |
-          echo "${API_KEY}" > secretfile.txt
-          echo "File content: $(cat secretfile.txt)"
+        run: echo "${API_KEY}" > secretfile.txt
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,11 +34,6 @@ jobs:
         with:
           context: ./Docker
           push: true
+          secret-files: mysecret=./secretfile.txt
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest
-
-      - name: Upload file as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: my-file-artifact
-          path: secretfile.txt

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,30 +9,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
-       - name: Set up environment variables
+      - name: Set up environment variables
         run: |
-        # Set up the API_KEY environment variable from the secret
-        echo "API_KEY=${{ secrets.API_KEY }}" >> $GITHUB_ENV
+          # Set up the API_KEY environment variable from the secret
+          echo "API_KEY=${{ secrets.API_KEY }}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up API Key
+
+      - name: Set up API Key
         run: |
           echo "API_KEY=${API_KEY}" > secretfile.txt
           echo "File content: $(cat secretfile.txt)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: ./Docker

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           # Set up the API_KEY environment variable from the secret
           echo "API_KEY=${{ secrets.API_KEY }}" >> $GITHUB_ENV
-          echo "$pwd/secretfile.txt"
+          
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -25,7 +25,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up API Key
-        run: echo "${API_KEY}" > secretfile.txt
+        run: | 
+            echo "${API_KEY}" > secretfile.txt
+            echo "$pwd/secretfile.txt"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          secrets: API= echo "${API_KEY}"
+          secrets: API= ${{ secrets.API_KEY }}
           file: ./Docker/Dockerfile
           push: true
           platforms: linux/arm64/v8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,7 @@ jobs:
         run: | 
             echo "${API_KEY}" > secretfile.txt
             echo "$pwd/secretfile.txt"
+            echo "File content: $(cat pwd/secretfile.txt)""
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,11 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./Docker
-          push: true
-          secret-files: ./secretfile.txt
-          platforms: linux/arm64/v8
-          tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest
+       - name: Build and push
+         run: docker buildx build \
+          --platform linux/arm64/v8 \
+          --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \
+          --secret id=mysecret,src=/run/secrets/mysecret \
+          ./Docker

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,6 @@ jobs:
         with:
           context: ./Docker
           push: true
-          secret-files: id=mysecret, scr=./secretfile.txt
+          secret-files: id=mysecret,src=./secretfile.txt
           platforms: linux/arm64/v8
           tags: ${{ secrets.DOCKER_USERNAME }}/iot:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,14 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
-        run: |
-          docker buildx create --use
-          # Here, specify the target platform, context, and any additional options
-          # Adjust the context and other options based on your Docker setup
-          # For example, replace ./Docker with your actual build context
-          docker buildx build \
-            --platform linux/arm64/v8 \
-            --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \
-            --secret id=mysecret,src=/run/secrets/mysecret \
-            ./Docker
+       - name: Build and push
+         run: docker buildx build \
+          --platform linux/arm64/v8 \
+          --tag ${{ secrets.DOCKER_USERNAME }}/iot:latest \
+          --secret mysecret=/run/secrets/mysecret \
+          ./Docker

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,7 @@ FROM python:latest
 WORKDIR /usr/app/src
 #*Adding API KEY
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret.txt
-RUN echo /usr/app/src/secret.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "python","./main.py",echo /usr/app/src/secret.txt]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile
+CMD [ "echo /usr/app/src/secret.txt" ]
+#*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,6 +6,5 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-RUN  cd ./secret
 CMD [ "ls" ]
 #*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,5 +6,5 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "ls" ]
+CMD [ "cat ./secretfile.txt" ]
 #*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,8 +3,7 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target= ./credentials
-RUN cat ./credentials
+RUN --mount=type=secret,id=API,target=/root/.aws/credentials
 COPY ./Docker/main.py ./
 #* running it
 CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,8 +3,7 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target=/usr/app/src/secret.txt cat /usr/app/src/secret.txt
+RUN --mount=type=secret,id=API,target=/usr/app/src/secret.txt echo /usr/app/src/secret.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "echo /usr/app/src/secret.txt" ]
-#*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile
+CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,6 @@ FROM python:latest
 WORKDIR /usr/app/src
 #*Adding API KEY
 RUN --mount=type=secret,id=API,target=/root/.aws/credentials
-RUN echo /root/.aws/credentials
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile
+CMD [ "python","./main.py",echo /root/.aws/credentials]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /usr/app/src
 #*Adding API KEY
 RUN --mount=type=secret,id=API,target=/root/.aws/credentials
 RUN cat /root/.aws/credentials
-COPY main.py ./Docker
+COPY ./Docker/main.py ./
 #* running it
 CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,5 +6,6 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "echo ./secretfile.txt" ]
+RUN  cd /usr/app/src/secret
+CMD [ "ls" ]
 #*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,6 +4,7 @@ FROM python:latest
 WORKDIR /usr/app/src
 #*Adding API KEY
 RUN --mount=type=secret,id=API,target=/root/.aws/credentials
+run echo /root/.aws/credentials
 COPY ./Docker/main.py ./
 #* running it
 CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target=/usr/app/src/secret.txt
+RUN --mount=type=secret,id=API,target=/usr/app/src/secret.txt cat /usr/app/src/secret.txt
 COPY ./Docker/main.py ./
 #* running it
 CMD [ "echo /usr/app/src/secret.txt" ]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,8 +3,8 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret, id=API, target=./
-RUN cat ./mysecret
+RUN --mount=type=secret,id=API,target=/root/.aws/credentials
+RUN cat /root/.aws/credentials
 COPY main.py ./
 #* running it
 CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,8 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target=/root/.aws/credentials
+RUN --mount=type=secret,id=API,target=/usr/app/src/secret.txt
+RUN echo /usr/app/src/secret.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "python","./main.py",echo /root/.aws/credentials]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile
+CMD [ "python","./main.py",echo /usr/app/src/secret.txt]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target=/usr/app/src/secret.txt echo /usr/app/src/secret.txt
+RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret
 COPY ./Docker/main.py ./
 #* running it
 CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,4 +6,7 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret cat /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile
+# Create a JSON file with your data
+RUN echo '{"id": "$(date +%s)", "value": 123.45, "scale": "F"}' > data.json
+CMD ["sh", "-c", "curl -X PUT -H 'X-Api-Key: $(cat ./secretfile.txt)' -d @data.json  iot.pxl.bjth.xyz/api/v1/temperature"]
+#*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,5 +6,5 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "cat ./secretfile.txt" ]
+CMD [ "cat secretfile.txt" ]
 #*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
+RUN --mount=type=secret,id=API,target=/usr/app/src/secret cat /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
 CMD [ "cat","./secretfile.txt" ]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,8 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret
+RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile
+CMD [ "echo ./secretfile.txt" ]
+#*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,5 +6,5 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "cat secretfile.txt" ]
+CMD [ "cat","./secretfile.txt" ]
 #*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -8,5 +8,5 @@ COPY ./Docker/main.py ./
 #* running it
 # Create a JSON file with your data
 RUN echo '{"id": "$(date +%s)", "value": 123.45, "scale": "F"}' > data.json
-CMD ["sh", "-c", "curl -X PUT -H 'X-Api-Key: $(cat ./secretfile.txt)' -d @data.json  iot.pxl.bjth.xyz/api/v1/temperature"]
+CMD ["sh", "-c", "curl -X PUT -H 'X-Api-Key: $(cat /usr/app/src/secret)' -d @data.json  iot.pxl.bjth.xyz/api/v1/temperature"]
 #*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret echo /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-RUN  cd /usr/app/src/secret
+RUN  cd ./secret
 CMD [ "ls" ]
 #*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /usr/app/src
 #*Adding API KEY
 RUN --mount=type=secret,id=API,target=/root/.aws/credentials
 RUN cat /root/.aws/credentials
-COPY main.py ./
+COPY main.py ./Docker
 #* running it
 CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,5 +6,4 @@ WORKDIR /usr/app/src
 RUN --mount=type=secret,id=API,target=/usr/app/src/secret cat /usr/app/src/secret > ./secretfile.txt
 COPY ./Docker/main.py ./
 #* running it
-CMD [ "cat","./secretfile.txt" ]
-#*CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile
+CMD [ "python","./main.py"]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,6 +2,9 @@
 FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
+#*Adding API KEY
+RUN --mount=type=secret, id=mysecret, target=./
+RUN cat ./mysecret
 COPY main.py ./
 #* running it
-CMD [ "python","./main.py" ]
+CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,7 @@ FROM python:latest
 WORKDIR /usr/app/src
 #*Adding API KEY
 RUN --mount=type=secret,id=API,target=/root/.aws/credentials
-run echo /root/.aws/credentials
+RUN echo /root/.aws/credentials
 COPY ./Docker/main.py ./
 #* running it
 CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret, id=mysecret, target=./
+RUN --mount=type=secret, id=API, target=./
 RUN cat ./mysecret
 COPY main.py ./
 #* running it

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,8 +3,8 @@ FROM python:latest
 #* Copying the main.py into the /usr/app/src/main.py
 WORKDIR /usr/app/src
 #*Adding API KEY
-RUN --mount=type=secret,id=API,target=/root/.aws/credentials
-RUN cat /root/.aws/credentials
+RUN --mount=type=secret,id=API,target= ./credentials
+RUN cat ./credentials
 COPY ./Docker/main.py ./
 #* running it
 CMD [ "python","./main.py" ]c:\02_PXL\IoT_Technologie_PXL_2024\Docker\Dockerfile

--- a/Docker/main.py
+++ b/Docker/main.py
@@ -1,3 +1,1 @@
-def main()
-    args = sys.argv[1:]
-    print(args)
+ print("Hey i am having a mental break down help?")

--- a/Docker/main.py
+++ b/Docker/main.py
@@ -1,1 +1,12 @@
- print("Hey i am having a mental break down help?")
+def read_and_print_file(file_path):
+    try:
+        with open(file_path, 'r') as file:
+            content = file.read()
+            print(content)
+    except FileNotFoundError:
+        print(f"File not found: {file_path}")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+file_path = './secretfile.txt'
+read_and_print_file(file_path)  

--- a/Docker/main.py
+++ b/Docker/main.py
@@ -1,4 +1,3 @@
-fo = open("/root/.aws/credentials", "r")
-str = fo.read(100)
-print ("Read String is : " + str)
-fo.close()
+def main()
+    args = sys.argv[1:]
+    print(args)

--- a/Docker/main.py
+++ b/Docker/main.py
@@ -1,4 +1,4 @@
 fo = open("/root/.aws/credentials", "r")
 str = fo.read(100)
-print "Read String is : ", str
+print ("Read String is : " + str)
 fo.close()

--- a/Docker/main.py
+++ b/Docker/main.py
@@ -8,5 +8,7 @@ def read_and_print_file(file_path):
     except Exception as e:
         print(f"An error occurred: {e}")
 
-file_path = './secretfile.txt'
+file_path = 'secretfile.txt'
 read_and_print_file(file_path)  
+
+print("I have a mental break down")

--- a/Docker/main.py
+++ b/Docker/main.py
@@ -1,1 +1,4 @@
-print("test")
+fo = open("/root/.aws/credentials", "r")
+str = fo.read(100)
+print "Read String is : ", str
+fo.close()


### PR DESCRIPTION
I tried a lot of shit so its a lot of commit messages. But basicly 

```yaml
secrets: API= ${{ secrets.API_KEY }}
```
this line tranfers the `API_KEY` github secret into a secret docker variable `API`

```dockerfile
RUN --mount=type=secret,id=API,target=/usr/app/src/secret cat /usr/app/src/secret > ./secretfile.txt
```
we ask docker in this line to search for the secret variable `API` and store it somewhere for this line. than we make a text file and put out `API` variable inside. 
> I know this is still  stored in plain text inside of the docker container but I may have some ideas to fix that in the future if needed. By doing arguments to main. so u can do `CMD [ "python","./main.py","cat /usr/app/src/secret"]`